### PR TITLE
refactor: make Playwright outputs less visible for better focus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,7 @@
 /playwright-report
 /test-results
 # playwright のカスタム出力先
-/playwright-results
-/playwright-snapshots
+/.playwright-*
 
 # Logs
 logs

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -32,13 +32,21 @@ export default defineConfig({
   // workers: process.env.CI ? 1 : undefined,
 
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: [['list'], ['html']],
+  reporter: [
+    ['list'],
+    [
+      'html',
+      {
+        // レポート出力先をデフォルトの playwright-report から変更。Playwright固有のファイルであることを明示しつつ目立たなくする
+        outputFolder: '.playwright-report',
+      },
+    ],
+  ],
 
-  // テスト結果の出力先をデフォルトの test-results から変更。Playwright固有のファイルであることを明示
-  outputDir: 'playwright-results',
-
-  // スナップショットの保存先をデフォルトの snapshots から変更。Playwright固有のファイルであることを明示
-  snapshotDir: 'playwright-snapshots',
+  // テスト結果の出力先をデフォルトの test-results から変更。Playwright固有のファイルであることを明示しつつ目立たなくする
+  outputDir: '.playwright-results',
+  // スナップショットの保存先をデフォルトの snapshots から変更。Playwright固有のファイルであることを明示しつつ目立たなくする
+  snapshotDir: '.playwright-snapshots',
 
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {


### PR DESCRIPTION
- Prefix all Playwright directories with dot (.) to reduce visual noise
- Consolidate gitignore patterns into single .playwright-* entry
- Move test outputs, snapshots and reports under hidden directories

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - Playwright関連の出力ディレクトリの設定を整理し、出力先を隠しディレクトリに変更しました。

- **新機能**
  - HTMLレポータの出力フォルダを新たに設定し、テスト結果の整理を改善しました。

- **ドキュメント**
  - `.gitignore`ファイルのパターンを簡素化し、Playwright関連の出力を一括で無視するようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->